### PR TITLE
Temperature anomaly, wind, precipitation stories fixed:

### DIFF
--- a/smartmet-library-textgen.spec
+++ b/smartmet-library-textgen.spec
@@ -4,8 +4,8 @@
 %define DEVELNAME %{SPECNAME}-devel
 Summary: textgen library
 Name: %{SPECNAME}
-Version: 17.5.18
-Release: 2%{?dist}.fmi
+Version: 17.5.23
+Release: 1%{?dist}.fmi
 License: FMI
 Group: Development/Libraries
 URL: https://github.com/fmidev/smartmet-library-textgen
@@ -62,6 +62,12 @@ FMI textgen development files
 %{_includedir}/smartmet/%{DIRNAME}
 
 %changelog
+* Tue May 23 2017 Anssi Reponen <anssi.reponen@fmi.fi> - 17.5.23-1.fmi
+- temperature anomaly story fixed: repeated sentence removed
+- wind forecast fixed: report wind speed even it is weak during whole forecast period 
+- precipitation forecast fixed: added missing check of type of precipitation when sentence is selected
+- weather forecast at sea fixed: whole forecast period need not to be reported if there is no non-weak precipitation
+
 * Thu May 18 2017 Anssi Reponen <anssi.reponen@fmi.fi> - 17.5.18-2.fmi
 - fixed wind speed reporting in first sentence
 

--- a/textgen/PrecipitationForecast.cpp
+++ b/textgen/PrecipitationForecast.cpp
@@ -824,7 +824,7 @@ void PrecipitationForecast::getPrecipitationPhraseElements(
       {
         if (thePrecipitationIntensity >= theParameters.theDryWeatherLimitWater)
         {
-          if (mostly_dry_weather)
+          if (mostly_dry_weather && thePrecipitationType == SHOWERS)
           {
             mostlyDryWeatherPhrase(is_showers,
                                    thePeriod,

--- a/textgen/TextGenerator.cpp
+++ b/textgen/TextGenerator.cpp
@@ -42,6 +42,8 @@
 #include <calculator/TextGenPosixTime.h>
 #include <newbase/NFmiStringTools.h>
 
+#define VERSION_STRING "17.5.23-1"
+
 using namespace TextGen;
 using namespace std;
 using namespace boost;

--- a/textgen/TextGenerator.h
+++ b/textgen/TextGenerator.h
@@ -10,8 +10,6 @@
 #include <boost/shared_ptr.hpp>
 #include <string>
 
-#define VERSION_STRING "17.5.16-1"
-
 class TextGenPosixTime;
 
 namespace TextGen

--- a/textgen/WindForecast.cpp
+++ b/textgen/WindForecast.cpp
@@ -1736,7 +1736,9 @@ void WindForecast::constructWindSentence2(const WindEventPeriodDataItem* windSpe
   if (is_weak_period(theParameters, windSpeedEventPeriod))
   {
     // weak period in the middle is not reported
-    if (firstSentence)
+    if (!firstSentence &&
+        get_period_length(windSpeedEventPeriod) !=
+            get_period_length(theParameters.theForecastPeriod))
     {
       theParameters.theLog << "Wind is weak on period " << as_string(windSpeedEventPeriod)
                            << " -> period is not reported" << std::endl;
@@ -1971,7 +1973,9 @@ std::vector<Sentence> WindForecast::constructWindSentence(
   // we dont report speed and direction changes on weak period
   if (is_weak_period(theParameters, windSpeedEventPeriod))
   {
-    if (!firstSentence)
+    if (!firstSentence &&
+        get_period_length(windSpeedEventPeriod) !=
+            get_period_length(theParameters.theForecastPeriod))
     {
       theParameters.theLog << "Wind is weak on period " << as_string(windSpeedEventPeriod)
                            << " -> period is not reported" << std::endl;

--- a/textgen/temperature_anomaly.cpp
+++ b/textgen/temperature_anomaly.cpp
@@ -634,16 +634,15 @@ const Sentence get_shortruntrend_sentence(const std::string& theDayAndAreaInclud
 
   if (theSpecifiedDay.size() > 0 && theAreaPhrase.size() > 0)
   {
-    sentence << theDayAndAreaIncludedCompositePhrase << theSpecifiedDay << theAreaPhrase
-             << theTemperatureSentence;
+    sentence << theDayAndAreaIncludedCompositePhrase << theSpecifiedDay << theAreaPhrase;
   }
   else if (theSpecifiedDay.size() > 0)
   {
-    sentence << theDayIncludedCompositePhrase << theSpecifiedDay << theTemperatureSentence;
+    sentence << theDayIncludedCompositePhrase << theSpecifiedDay;
   }
   else if (theAreaPhrase.size() > 0)
   {
-    sentence << theAreaIncludedCompositePhrase << theAreaPhrase << theTemperatureSentence;
+    sentence << theAreaIncludedCompositePhrase << theAreaPhrase;
   }
   else
   {


### PR DESCRIPTION
- temperature anomaly story fix: repeated sentence removed
- wind forecast fix: report wind speed even it is weak during whole forecast period
- precipitation forecast fix: added missing check of type of precipitation when sentence is selected
- weather forecast at sea fix: whole forecast period need not to be reported if there is no non-weak precipitation