### PR TITLE
Bug fixes in wind and weather forecasts:

### DIFF
--- a/smartmet-library-textgen.spec
+++ b/smartmet-library-textgen.spec
@@ -4,7 +4,7 @@
 %define DEVELNAME %{SPECNAME}-devel
 Summary: textgen library
 Name: %{SPECNAME}
-Version: 17.6.14
+Version: 17.8.22
 Release: 1%{?dist}.fmi
 License: FMI
 Group: Development/Libraries
@@ -62,6 +62,14 @@ FMI textgen development files
 %{_includedir}/smartmet/%{DIRNAME}
 
 %changelog
+* Tue Aug 22 2017 Anssi Reponen <anssi.reponen@fmi.fi> - 17.8.22-1.fmi
+- fixed reporting of wind direction when wind speed doesn't change 
+- fixed logic how right time phrase is decided: strict period borders are not used, but coverage is inspected instead (at least 80% must be inside the phrase period)
+- dont report bad visibility when precipitation form is water
+- fixed reporting of similar wind speed intervas in successive sentences
+- fixed handling of varying wind (don't report strengthening wind when direction is varying)
+- fixed missing rain in visibility forecast
+
 * Wed Jun 14 2017 Anssi Reponen <anssi.reponen@fmi.fi> - 17.6.14-1.fmi
 - bad visibility ('huono näkyvyys') logic added
 - new configuration parameter 'short_text_mode' added for forecast_at_sea-story

--- a/textgen/PrecipitationForecast.h
+++ b/textgen/PrecipitationForecast.h
@@ -33,16 +33,18 @@ class PrecipitationForecast
   PrecipitationForecast(wf_story_params& parameters);
   ~PrecipitationForecast();
 
-  Sentence precipitationChangeSentence(const WeatherPeriod& thePeriod,
-                                       const Sentence& thePeriodPhrase,
-                                       weather_event_id theWeatherEvent,
-                                       std::vector<Sentence>& theAdditionalSentences) const;
+  Sentence precipitationChangeSentence(
+      const WeatherPeriod& thePeriod,
+      const Sentence& thePeriodPhrase,
+      weather_event_id theWeatherEvent,
+      std::vector<std::pair<WeatherPeriod, Sentence>>& theAdditionalSentences) const;
   Sentence precipitationPoutaantuuAndCloudiness(const Sentence& thePeriodPhrase,
                                                 cloudiness_id theCloudinessId) const;
 
-  Sentence precipitationSentence(const WeatherPeriod& thePeriod,
-                                 const Sentence& thePeriodPhrase,
-                                 std::vector<Sentence>& theAdditionalSentences) const;
+  Sentence precipitationSentence(
+      const WeatherPeriod& thePeriod,
+      const Sentence& thePeriodPhrase,
+      std::vector<std::pair<WeatherPeriod, Sentence>>& theAdditionalSentences) const;
   bool shortTermPrecipitationExists(const WeatherPeriod& thePeriod) const;
   Sentence shortTermPrecipitationSentence(const WeatherPeriod& thePeriod,
                                           const Sentence& thePeriodPhrase) const;
@@ -224,11 +226,12 @@ class PrecipitationForecast
       precipitation_form_transformation_id theTransformationId,
       std::map<std::string, Sentence>& theCompositePhraseElements) const;
 
-  Sentence constructPrecipitationSentence(const WeatherPeriod& thePeriod,
-                                          const Sentence& thePeriodPhrase,
-                                          unsigned short theForecastAreaId,
-                                          const std::string& theAreaPhrase,
-                                          std::vector<Sentence>& theAdditionalSentences) const;
+  Sentence constructPrecipitationSentence(
+      const WeatherPeriod& thePeriod,
+      const Sentence& thePeriodPhrase,
+      unsigned short theForecastAreaId,
+      const std::string& theAreaPhrase,
+      std::vector<std::pair<WeatherPeriod, Sentence>>& theAdditionalSentences) const;
 
   void calculatePrecipitationParameters(const WeatherPeriod& thePeriod,
                                         const precipitation_data_vector& theDataVector,

--- a/textgen/TextGenerator.cpp
+++ b/textgen/TextGenerator.cpp
@@ -42,7 +42,7 @@
 #include <calculator/TextGenPosixTime.h>
 #include <newbase/NFmiStringTools.h>
 
-#define VERSION_STRING "17.6.14-1"
+#define VERSION_STRING "17.8.22-1"
 
 using namespace TextGen;
 using namespace std;

--- a/textgen/WeatherForecast.h
+++ b/textgen/WeatherForecast.h
@@ -175,6 +175,7 @@ class GlyphContainer;
 #define ENIMMAKSEEN_HYVA_NAKYVYYS_PHRASE "enimmakseen hyva nakyvyys"
 #define MUUTEN_HYVA_NAKYVYYS_PHRASE "muuten hyva nakyvyys"
 #define JA_HUONO_NAKYVYYS_PHRASE "ja huono nakyvyys"
+#define HUONO_NAKYVYYS_PHRASE "huono nakyvyys"
 
 #define SADEALUE_WORD "sadealue"
 #define SAAPUU_WORD "saapuu"
@@ -637,7 +638,7 @@ std::string get_time_phrase(const TextGenPosixTime& theTimestamp,
                             bool theAlkaenPhrase = false);
 std::string get_time_phrase_from_id(part_of_the_day_id thePartOfTheDayId,
                                     const std::string& theVar,
-                                    bool theAlkaenPhrase = false);
+                                    bool theAlkaenPhrase);
 Sentence get_today_phrase(const TextGenPosixTime& theEventTimestamp,
                           const std::string& theVariable,
                           const WeatherArea& theArea,

--- a/textgen/WeatherForecastStory.h
+++ b/textgen/WeatherForecastStory.h
@@ -8,6 +8,22 @@ class Sentence;
 class Paragraph;
 class WeatherForecastStory;
 
+class PeriodPhraseGenerator
+{
+ public:
+  PeriodPhraseGenerator(const std::string& var) : itsVar(var) {}
+
+  bool dayExists(int n) const;
+  bool phraseExists(const WeatherPeriod& period) const;
+  Sentence getPeriodPhrase(const WeatherPeriod& period);
+  void reset();
+
+ private:
+  std::set<int> dayNumbers;
+  std::map<WeatherPeriod, Sentence> periodPhrases;
+  const std::string& itsVar;
+};
+
 class WeatherForecastStoryItem
 {
  public:
@@ -38,10 +54,10 @@ class WeatherForecastStoryItem
   const WeatherPeriod& getPeriod() const { return thePeriod; }
   bool isIncluded() const { return theIncludeInTheStoryFlag; }
   unsigned int numberOfAdditionalSentences() { return theAdditionalSentences.size(); }
-  Sentence getAdditionalSentence(unsigned int index) const;
+  std::pair<WeatherPeriod, Sentence> getAdditionalSentence(unsigned int index) const;
 
- protected:
-  std::vector<Sentence> theAdditionalSentences;
+  // protected:
+  std::vector<std::pair<WeatherPeriod, Sentence>> theAdditionalSentences;
   WeatherForecastStory& theWeatherForecastStory;
   WeatherPeriod thePeriod;
   story_part_id theStoryPartId;
@@ -50,8 +66,6 @@ class WeatherForecastStoryItem
   Sentence theSentence;
   WeatherForecastStoryItem*
       thePeriodToMergeWith;  // if periods are merged this points to the megreable period
-  WeatherForecastStoryItem*
-      thePeriodToMergeTo;  // if periods are merged this points to the merged period
 
   friend class WeatherForecastStory;
 
@@ -71,6 +85,9 @@ class PrecipitationForecastStoryItem : public WeatherForecastStoryItem
                                  bool thunder);
 
   Sentence getStoryItemSentence();
+  bool isWeakPrecipitation(const wf_story_params& theParameters) const;
+  float precipitationExtent() const;
+  unsigned int precipitationForm() const;
 
  private:
   float theIntensity;
@@ -124,7 +141,7 @@ class WeatherForecastStory
   WeatherForecastStory(const std::string& var,
                        const TextGen::WeatherPeriod& forecastPeriod,
                        const TextGen::WeatherArea& weatherArea,
-                       const wf_story_params& parameters,
+                       wf_story_params& parameters,
                        const TextGenPosixTime& forecastTime,
                        PrecipitationForecast& precipitationForecast,
                        const CloudinessForecast& cloudinessForecast,
@@ -141,6 +158,8 @@ class WeatherForecastStory
   {
     return theStoryItemVector;
   }
+  Sentence getPeriodPhrase(const WeatherPeriod& period);
+
   void logTheStoryItems() const;
 
  private:
@@ -154,7 +173,7 @@ class WeatherForecastStory
   const std::string theVar;
   const WeatherPeriod& theForecastPeriod;
   const WeatherArea& theWeatherArea;
-  const wf_story_params& theParameters;
+  wf_story_params& theParameters;
   const TextGenPosixTime& theForecastTime;
   const PrecipitationForecast& thePrecipitationForecast;
   const CloudinessForecast& theCloudinessForecast;
@@ -165,6 +184,7 @@ class WeatherForecastStory
   bool theShortTimePrecipitationReportedFlag;
   bool theReportTimePhraseFlag;
   bool theCloudinessReportedFlag;
+  PeriodPhraseGenerator thePeriodPhraseGenerator;
 
   std::vector<WeatherForecastStoryItem*> theStoryItemVector;
 

--- a/textgen/WindForecast.h
+++ b/textgen/WindForecast.h
@@ -114,26 +114,15 @@ class WindForecast
  private:
   wo_story_params& theParameters;
 
-  std::vector<Sentence> constructWindSentence(
-      const WindEventPeriodDataItem* windSpeedItem,
-      const WindEventPeriodDataItem* nextWindSpeedItem,
-      std::vector<WeatherPeriod> windDirectionReportingPoints,
-      WindDirectionInfo& thePreviousWindDirection,
-      TimePhraseInfo& thePreviousTimePhrase,
-      bool firstSentence) const;
-
-  void constructWindSentence2(const WindEventPeriodDataItem* windSpeedItem,
-                              const WindEventPeriodDataItem* nextWindSpeedItem,
-                              const WindDirectionPeriodInfo& firstDirectionPeriodInfo,
-                              WindDirectionInfo& thePreviousWindDirection,
-                              WindSpeedSentenceInfo& sentenceInfoVector) const;
+  void constructWindSentence(const WindEventPeriodDataItem* windSpeedItem,
+                             const WindEventPeriodDataItem* nextWindSpeedItem,
+                             const WindDirectionPeriodInfo& firstDirectionPeriodInfo,
+                             WindDirectionInfo& thePreviousWindDirection,
+                             WindSpeedSentenceInfo& sentenceInfoVector) const;
 
   Sentence windDirectionSentenceWithAttribute(
       WindStoryTools::WindDirectionId theWindDirectionId) const;
   Sentence windSpeedIntervalSentence(const WeatherPeriod& thePeriod,
-                                     bool theUseAtItsStrongestPhrase = true) const;
-  Sentence windSpeedIntervalSentence(const WeatherPeriod& thePeriodLowerLimit,
-                                     const WeatherPeriod& thePeriodUpperLimit,
                                      bool theUseAtItsStrongestPhrase = true) const;
   Sentence speedRangeSentence(const WeatherPeriod& thePeriod,
                               bool theUseAtItsStrongestPhrase) const;
@@ -160,7 +149,9 @@ class WindForecast
                                                const TimePhraseInfo& thePreviousTimePhraseInfo,
                                                bool theTuuliBasicForm) const;
   std::vector<sentence_parameter> reportWindDirectionChanges2(
-      const std::vector<WindDirectionInfo>& directionChanges, TimePhraseInfo& timePhraseInfo) const;
+      const std::vector<WindDirectionInfo>& directionChanges,
+      TimePhraseInfo& timePhraseInfo,
+      bool startWithComma = true) const;
 
   std::vector<Sentence> reportDirectionChanges(const WeatherPeriod& thePeriod,
                                                std::vector<WeatherPeriod>& theDirectionPeriods,
@@ -168,15 +159,10 @@ class WindForecast
                                                TimePhraseInfo& thePreviousTimePhrase,
                                                bool lastPeriod,
                                                bool voimistuvaa) const;
-  void injectWindDirections(const wo_story_params& theParameters,
-                            WindSpeedSentenceInfo& sentenceInfoVector,
-                            const std::vector<WeatherPeriod>& windDirectionPeriods) const;
-  void checkWindSpeedIntervals(WindSpeedSentenceInfo& sentenceInfoVector,
-                               const std::vector<WeatherPeriod>& windDirectionPeriods) const;
-  Paragraph constructParagraph(
-      const WeatherPeriod& thePeriod,
-      const WindSpeedSentenceInfo& sentenceInfoVector,
-      const std::vector<WindDirectionPeriodInfo>& directionInfoVector) const;
+  void injectWindDirections(WindSpeedSentenceInfo& sentenceInfoVector) const;
+  void checkWindSpeedIntervals(WindSpeedSentenceInfo& sentenceInfoVector) const;
+  Paragraph constructParagraph(const WeatherPeriod& thePeriod,
+                               const WindSpeedSentenceInfo& sentenceInfoVector) const;
   interval_info windSpeedIntervalInfo(const WeatherPeriod& thePeriod) const;
   Sentence reportWindDirectionChanges(const std::vector<WindDirectionInfo>& directionChanges,
                                       TimePhraseInfo& timePhraseInfo) const;
@@ -200,10 +186,8 @@ class WindForecast
   Sentence windSpeedIntervalSentence2(const WeatherPeriod& thePeriod,
                                       TimePhraseInfo& tpi,
                                       bool theUseAtItsStrongestPhrase = true) const;
-  ParagraphInfoVector getParagraphInfo(
-      const WeatherPeriod& thePeriod,
-      const WindSpeedSentenceInfo& sentenceInfoVector,
-      const std::vector<WindDirectionPeriodInfo>& directionInfoVector) const;
+  ParagraphInfoVector getParagraphInfo(const WeatherPeriod& thePeriod,
+                                       const WindSpeedSentenceInfo& sentenceInfoVector) const;
 };
 
 }  // namespace TextGen

--- a/textgen/WindForecastStructs.h
+++ b/textgen/WindForecastStructs.h
@@ -102,6 +102,7 @@ struct wo_story_params
   wind_speed_period_data_item_vector theWindSpeedVector;
   wind_direction_period_data_item_vector theWindDirectionVector;
   wind_event_period_data_item_vector theWindSpeedEventPeriodVector;
+  std::vector<WeatherPeriod> theWindDirectionPeriods;
 
   std::map<WeatherArea::Type, index_vectors*> indexes;
 
@@ -352,6 +353,12 @@ bool wind_speed_differ_enough(const wo_story_params& theParameter, const Weather
 bool wind_direction_differ_enough(const WeatherResult theWindDirection1,
                                   const WeatherResult theWindDirection2,
                                   float theWindDirectionThreshold);
+WindDirectionInfo get_wind_direction(const wo_story_params& theParameters,
+                                     const TextGenPosixTime& pointOfTime,
+                                     const WindDirectionInfo* thePreviousWindDirection = 0);
+WindDirectionInfo get_wind_direction(const wo_story_params& theParameters,
+                                     const WeatherPeriod& period,
+                                     const WindDirectionInfo* thePreviousWindDirection = 0);
 
 bool is_weak_period(const wo_story_params& theParameters, const WeatherPeriod& thePeriod);
 

--- a/textgen/weather_forecast.cpp
+++ b/textgen/weather_forecast.cpp
@@ -1338,7 +1338,7 @@ const Paragraph weather_forecast(const TextGen::WeatherArea& itsArea,
 
   paragraph << wfs.getWeatherForecastStory();
 
-  log_weather_forecast_story(theLog, wfs);
+  //  log_weather_forecast_story(theLog, wfs);
 
   delete_data_structures(theParameters);
 


### PR DESCRIPTION
- fixed reporting of wind direction when wind speed doesn't change
- fixed logic on how right time phrase is decided: strict period borders are not used, but coverage is inspected instead (at least 80% must be inside the phrase period)
- dont report bad visibility when precipitation form is water
- fixed reporting of similar wind speed intervas in successive sentences
- fixed handling of varying wind (don't report strengthening wind when direction is varying)
- fixed missing rain in visibility forecast